### PR TITLE
Fixed path reference issues in update_gen.py

### DIFF
--- a/scionLab.sh
+++ b/scionLab.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This file is located in $SCIONBOX and called periodically by cron or systemd
 
-export PYTHONPATH=../scion/.:../scion/python/:sub/util/:.
+export PYTHONPATH=$SC:$SC/python:sub/util/:.
 
 python3 ./update_gen.py

--- a/update_gen.py
+++ b/update_gen.py
@@ -505,8 +505,8 @@ def generate_local_gen(my_asid, as_obj, tp):
             write_zlog_file(service_type, instance_name, instance_path)
     # We don't need to create zk configration for existing ASes
     # generate_zk_config(tp, ia, GEN_PATH, simple_conf_mode=False)
-    generate_sciond_config(ia, as_obj, tp)
-    generate_prom_config(ia, tp)
+    generate_sciond_config(ia, as_obj, tp, gen_path)
+    generate_prom_config(ia, tp, gen_path)
 
 
 def _restart_scion():


### PR DESCRIPTION
@mlegner,
As you mentioned in #21, we have to adjust some paths in `update_gen.py` to make it run without any path reference problem. Now, I fixed code to make all the methods refering the SCION main codebase run with absolute path information, so that `update_gen.py` could run no matter where the file would be located in.

`scionLab.sh` should be fixed in near future as soon as we determine the exact location of the file. Current version of `scionLab.sh` is fixed under the assumption that it will be in the root directory of `scion-box` repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-box/23)
<!-- Reviewable:end -->
